### PR TITLE
updated cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if (CUDA_FOUND)
     # With recent versions of Xcode, must explicitly use clang
     set(CUDA_HOST_COMPILER /usr/bin/clang)
   endif()
-  set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-O2;
+  set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-O2;-Xcompiler=-fPIC;
     -gencode=arch=compute_30,code=sm_30;
     -gencode=arch=compute_35,code=sm_35;
     -gencode=arch=compute_50,code=sm_50)

--- a/cmake_modules/FindFFTW.cmake
+++ b/cmake_modules/FindFFTW.cmake
@@ -9,11 +9,13 @@ ELSE(FFTW_INCLUDE_DIRS)
     SET(TRIAL_PATHS
       /opt/fftw-3.2/usr/include
       /usr/include
+      $ENV{FFTW_INC}
     )
     SET(TRIAL_LIBRARY_PATHS
       /opt/fftw-3.2/usr/lib64
       /usr/lib
       /usr/lib64
+      $ENV{FFTW_DIR}
       )
     FIND_PATH(FFTW_INCLUDE_DIR fftw3.h ${TRIAL_PATHS})
     FIND_LIBRARY(FFTW_LIBRARY fftw3 ${TRIAL_LIBRARY_PATHS})


### PR DESCRIPTION
There are two changes in the Cmake files:
1. add one extra default path for finding FFTW
2. add "-Xcompiler=-fPIC" for nvcc, to generate position-independent library, otherwise compiler on Titan complains. 